### PR TITLE
Adding instructions to README file for set up a local development env

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,38 @@ Then import the package:
 import cybrid_api_id
 ```
 
+### Setting up a development environment with Docker
+Make sure you have [Docker installed](https://docs.docker.com/get-docker/) on your machine.
+
+Clone the repository to your local machine using Git. For example, you can run the following command in your terminal:
+```bash
+git clone https://github.com/Cybrid-app/cybrid-api-id-python.git
+```
+Navigate to the project directory:
+```bash
+cd cybrid-api-id-python
+```
+Create a Docker container:
+```bash
+docker run -it --name cybrid-api-id-python-dev  -v /opt/phx -v /$(pwd):/opt python:3.11 bash
+```
+Navigate to the project directory in the Docker contianer:
+```bash
+cd opt
+```
+Install the required dependencies:
+```bash
+pip install -r requirements.txt && pip install pytest
+```
+Run the unit tests to make sure everything is working properly:
+```bash
+pytest
+```
+Starts a Docker container:
+```bash
+docker container start -i cybrid-api-id-python-dev
+```
+
 ### Setuptools
 
 Install via [Setuptools](http://pypi.python.org/pypi/setuptools).

--- a/README.md
+++ b/README.md
@@ -180,12 +180,19 @@ Navigate to the project directory:
 cd cybrid-api-id-python
 ```
 Create a Docker container:
+For Windows:
+
+CMD:
 ```bash
-docker run -it --name cybrid-api-id-python-dev  -v /opt/phx -v /$(pwd):/opt python:3.11 bash
+docker run -it --name cybrid-api-id-python-dev -w /opt -v %cd%:/opt python:3.11 bash
 ```
-Navigate to the project directory in the Docker contianer:
+PowerShell:
 ```bash
-cd opt
+docker run -it --name cybrid-api-id-python-dev -w /opt -v ${PWD}:/opt python:3.11 bash
+```
+For Linux:
+```bash
+docker run -it --name cybrid-api-id-python-dev -w /opt -v $(PWD):/opt python:3.11 bash
 ```
 Install the required dependencies:
 ```bash


### PR DESCRIPTION
Hi, this PR was sent as part of [OSDC](https://osdc.code-maven.com/) taught by: @szabgab. I want to contribute to your project by adding instructions on how to set up a local development environment using Docker in the project's README file. Is important for several reasons:

Ease of onboarding: new contributors or developers joining the project may not be familiar with the required software and libraries needed to develop and run the project. Providing clear instructions on how to set up a local development environment using Docker, it makes it easier for them to get up and running quickly.
Reproducibility: By using Docker to set up the local development environment, it ensures that all developers are using the same development environment with the same versions of software and libraries. This makes it easier to reproduce bugs and issues reported by other developers, as well as ensure that the project is built and tested in a consistent manner across different environments.
Isolation: Docker allows developers to create a containerized environment that is isolated from the host system, preventing potential conflicts with other software installed on the host. This helps ensure that the project's dependencies do not conflict with other software, potentially causing issues or breaking the development environment.
Thanks,
Ran